### PR TITLE
Fix test for recent versions of Catalyst

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,7 @@ requires 'Path::Class'; # included with Catalyst though
 requires 'Catalyst::Component::ACCEPT_CONTEXT' => 0.03;
 requires 'Class::C3';
 
-build_requires 'Catalyst' => '5.7001';
+build_requires 'Catalyst' => '5.9007';
 build_requires 'Test::More';
 build_requires 'Test::WWW::Mechanize::Catalyst';
 build_requires 'ok';

--- a/t/basics.t
+++ b/t/basics.t
@@ -11,6 +11,8 @@ use lib "$Bin/lib";
 use ok 'TestApp::View::Something';
 use MockCatalyst;
 
+local $Storable::canonical = 1;
+
 my @STASH_EXTRAS = (base => 'base', name => 'TestApp');
 
 $stash = {something => 'here'};

--- a/t/lib/TestApp/Controller/Root.pm
+++ b/t/lib/TestApp/Controller/Root.pm
@@ -9,16 +9,16 @@ __PACKAGE__->config(namespace => q{});
 sub template_detach :Local {
     my ($self, $c) = @_;
     
-    $c->view('View::Something')->template('hello_world');
+    $c->view('Something')->template('hello_world');
     $c->stash(hello => 'world');
     
-    $c->detach($c->view('View::Something'));
+    $c->detach($c->view('Something'));
 }
 
 sub action_detach :Local {
     my ($self, $c) = @_;
     $c->stash(action => 'detach');    
-    $c->detach($c->view('View::Something'));
+    $c->detach($c->view('Something'));
 }
 
 sub local_config :Local {

--- a/t/lib/TestApp/View/Something.pm
+++ b/t/lib/TestApp/View/Something.pm
@@ -5,6 +5,8 @@ use warnings;
 use base 'Catalyst::View::Templated';
 use Storable qw/freeze/;
 
+$Storable::forgive_me = 1;
+
 sub _render {
     my $self = shift;
     my $template = shift;
@@ -12,7 +14,11 @@ sub _render {
     
     $self->context->response->content_type('application/octet-stream');
     
-    return freeze({ $template => $stash });
+    # Because Storable
+    my %safe_stash = %$stash;
+    delete $safe_stash{c} if defined $safe_stash{c} && $safe_stash{c}->isa('Catalyst');
+
+    return freeze({ $template => \%safe_stash });
 }
 
 1;


### PR DESCRIPTION
This should correct the problem reported in CPAN RT (https://rt.cpan.org/Public/Bug/Display.html?id=76064).

There are two main fixes:
1. Removing the redundant "View::" from calls to `->view()`.
2. Keeping the Catalyst object away from Storable since it generally contains lots of stuff these days that annoys it.
